### PR TITLE
Fixup Windows path errors and support latest PyTorch

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+import os
+
 from dataclasses import dataclass
 from torch.optim import Adam
 
@@ -25,8 +27,8 @@ class TrainSegmentatorConfig:
     seed: int = 0
 
     # Paths
-    input_dir: str = ".data/input"
-    output_dir: str = ".data/output"
+    input_dir: str = os.path.join(".data", "input")
+    output_dir: str = os.path.join(".data", "output")
 
     # Data
     size: int = 20_000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117
+pytorch-lightning
+monai
+tensorboard
+
+./pointnet2_ops_lib/

--- a/src/metrics/confusion_matrix.py
+++ b/src/metrics/confusion_matrix.py
@@ -1,10 +1,10 @@
 import torch
 from torchmetrics.classification.confusion_matrix import (
-    ConfusionMatrix as TorchConfusionMatrix,
+    MulticlassConfusionMatrix as TorchMulticlassConfusionMatrix,
 )
 
 
-class ConfusionMatrix(TorchConfusionMatrix):
+class ConfusionMatrix(TorchMulticlassConfusionMatrix):
     def __call__(self, pred: torch.Tensor, label: torch.Tensor):
         values = super().__call__(pred.flatten(), label.flatten())
         self.TN = values[0, 0]

--- a/train.py
+++ b/train.py
@@ -17,7 +17,7 @@ def train():
     np.random.seed(config.seed)
 
     # Init out directories
-    ct = datetime.datetime.now().strftime("%m-%d-%Y.%H:%M:%S")
+    ct = datetime.datetime.now().strftime("%m-%d-%Y-%H-%M-%S")
     logs_path = os.path.join(config.output_dir, ct, "logs")
     checkpoint_path = os.path.join(config.output_dir, ct, "checkpoint")
 


### PR DESCRIPTION
The errors on Windows were caused by invalid path separators used in config.py and date-time formatting used for directory names.
Modern PyTorch refactored ConfusionMatrix into separate classes, which required adjustment here.